### PR TITLE
Refactor to use Web Audio API

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "react-native-web",
     "react-native-sound"
   ],
-  "dependencies": {
-    "howler": "^2.2.1"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "react-native-web": "*"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -34,9 +34,6 @@ Sound.prototype.play = function(onEnd) {
   if (this.audioContext.state === 'suspended') {
     this.audioContext.resume()
   } else {
-    this.source = this.audioContext.createBufferSource()
-    this.source.buffer = this.source.buffer
-    this.source.connect(this.gainNode)
     this.source.start(0, this.currentPlaybackPosition)
   }
   this.source.onended = () => onEnd && onEnd(true)

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,7 @@ Sound.prototype.reset = function() { return this }
 
 Sound.prototype.release = function() {
   this.stop()
+  this.audioContext.close()
   return this
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,18 @@
-import { Howl, Howler } from 'howler'
-
 export default function Sound(asset, basePath, onError) {
-  this.sound = new Howl({
-    src: [asset],
-    onload: onError,
-    onloaderror: (id, error) => onError && onError(`Got error: ${error}`),
-  })
+  this.audioContext = new (window.AudioContext || window.webkitAudioContext)()
+  this.source = this.audioContext.createBufferSource()
+  this.gainNode = this.audioContext.createGain()
+  this.source.connect(this.gainNode)
+  this.gainNode.connect(this.audioContext.destination)
+
+  fetch(asset)
+    .then(response => response.arrayBuffer())
+    .then(data => this.audioContext.decodeAudioData(data))
+    .then(buffer => {
+      this.source.buffer = buffer
+      onError && onError()
+    })
+    .catch(error => onError && onError(`Got error: ${error}`))
 }
 
 Sound.enable = () => {}
@@ -15,7 +22,7 @@ Sound.setMode = () => {}
 Sound.setSpeakerPhone = () => {}
 
 Sound.prototype.isLoaded = function () {
-  return this.sound.state() === 'loaded'
+  return this.source.buffer !== null
 }
 
 Sound.prototype.play = function(onEnd) {
@@ -23,19 +30,19 @@ Sound.prototype.play = function(onEnd) {
     onEnd && onEnd(false)
     return this
   }
-  if (onEnd) this.sound.once('end', () => onEnd(true))
-  this.sound.play()
+  this.source.start(0)
+  this.source.onended = () => onEnd && onEnd(true)
   return this
 }
 
 Sound.prototype.pause = function() {
   if (!this.isLoaded()) return this
-  this.sound.pause()
+  this.source.stop(0)
   return this
 }
 
 Sound.prototype.stop = function() {
-  this.sound.stop()
+  this.source.stop(0)
   return this
 }
 
@@ -46,48 +53,54 @@ Sound.prototype.release = function() {
   return this
 }
 
-Sound.prototype.getNumberOfChannels = function() { return -1 }
+Sound.prototype.getNumberOfChannels = function() { return this.source.buffer.numberOfChannels }
 
-Sound.prototype.getDuration = function() { return this.sound.duration() }
+Sound.prototype.getDuration = function() { return this.source.buffer.duration }
 
-Sound.prototype.getVolume = function() { return this.sound.volume() }
+Sound.prototype.getVolume = function() { return this.gainNode.gain.value }
 
 Sound.prototype.setVolume = function(volume) {
-  this.sound.volume(volume)
+  this.gainNode.gain.value = volume
   return this
 }
 
-Sound.prototype.getSystemVolume = () => Howler.volume()
+Sound.prototype.getSystemVolume = () => 1 // Web Audio API does not have a global volume control
 
-Sound.prototype.setSystemVolume = (v) => Howler.volume(v)
+Sound.prototype.setSystemVolume = (v) => {} // Web Audio API does not have a global volume control
 
-Sound.prototype.getNumberOfLoops = function() { return this.sound.loop() ? -1 : 0 }
+Sound.prototype.getNumberOfLoops = function() { return this.source.loop ? -1 : 0 }
 
 Sound.prototype.setNumberOfLoops = function(n) {
-  this.sound.loop(n === -1)
+  this.source.loop = (n === -1)
   return this
 }
 
 Sound.prototype.setSpeed = function(v) {
-  this.sound.rate(v)
+  this.source.playbackRate.value = v
   return this
 }
 
 Sound.prototype.setPan = function(v) {
-  this.sound.stereo(v)
+  if (!this.pannerNode) {
+    this.pannerNode = this.audioContext.createStereoPanner()
+    this.source.connect(this.pannerNode)
+    this.pannerNode.connect(this.audioContext.destination)
+  }
+  this.pannerNode.pan.value = v
   return this
 }
 
-Sound.prototype.getPan = function() { return this.sound.stereo() }
+Sound.prototype.getPan = function() { return this.pannerNode ? this.pannerNode.pan.value : 0 }
 
-Sound.prototype.getCurrentTime = function() { return this.sound.seek() }
+Sound.prototype.getCurrentTime = function() { return this.audioContext.currentTime }
 
 Sound.prototype.setCurrentTime = function(v) {
-  this.sound.seek(v)
+  this.source.stop(0)
+  this.source.start(0, v)
   return this
 }
 
-Sound.prototype.isPlaying = function() { return this.sound.playing() }
+Sound.prototype.isPlaying = function() { return this.source.playbackState === this.source.PLAYING_STATE }
 
 Sound.prototype.setCategory = () => {}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,3 @@
 # yarn lockfile v1
 
 
-howler@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.1.tgz#a521a9b495841e8bb9aa12e651bebba0affc179e"
-  integrity sha512-0iIXvuBO/81CcrQ/HSSweYmbT50fT2mIc9XMFb+kxIfk2pW/iKzDbX1n3fZmDXMEIpYvyyfrB+gXwPYSDqUxIQ==


### PR DESCRIPTION
Refactor `src/index.js` to use the Web Audio API instead of the `howler` library.

* Replace `howler` import with Web Audio API.
* Refactor `Sound` class to use Web Audio API for audio functionality.
* Update `Sound` class methods to use Web Audio API for play, pause, stop, volume control, and looping.
* Remove `howler` specific methods and properties.

Remove `howler` dependency from `package.json` and update `yarn.lock` accordingly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mybigday/react-native-web-sound/pull/1?shareId=6049d360-98cf-4e7c-827a-186f244dd9fa).